### PR TITLE
add element_share type to MessageButton Class

### DIFF
--- a/Messages/MessageButton.php
+++ b/Messages/MessageButton.php
@@ -19,6 +19,11 @@ class MessageButton
     const TYPE_POSTBACK = "postback";
     
     /**
+     * Postback button type
+     */
+    const TYPE_SHARE = "element_share";
+    
+    /**
      * Account link type
      */
     const TYPE_ACCOUNT_LINK = "account_link";
@@ -77,7 +82,7 @@ class MessageButton
      * @param string $title
      * @param string $url url or postback
      */
-    public function __construct($type, $title, $url = '', $webview_height_ratio = '', $messenger_extensions = false, $fallback_url = '')
+    public function __construct($type, $title = '', $url = '', $webview_height_ratio = '', $messenger_extensions = false, $fallback_url = '')
     {
         $this->type = $type;
         $this->title = $title;
@@ -128,6 +133,10 @@ class MessageButton
            
             case self::TYPE_ACCOUNT_UNLINK:
               //only type needed
+            break;
+            
+            case self::TYPE_SHARE:
+              //only type needed  
             break;
         }
 


### PR DESCRIPTION
add the type element_share to MessageButton class. I made title optional on the constructor because element_share type does not require to have a title. more on https://developers.facebook.com/docs/messenger-platform/send-api-reference/share-button