### PR TITLE
v1.4: getStarted and persistent menu 

### DIFF
--- a/FbBotApp.php
+++ b/FbBotApp.php
@@ -129,15 +129,15 @@ class FbBotApp
      * Set Nested Menu
      *
      * @see https://developers.facebook.com/docs/messenger-platform/messenger-profile/persistent-menu
-     * @param Menu\MenuItem[] $menuItems
+     * @param Menu\LocalizedMenu[] $localizedMenu
      * @return array
      */
-    public function setPersistentMenu($menuItems)
+    public function setPersistentMenu($localizedMenu)
     {
         $elements = [];
 
-        foreach ($menuItems as $item) {
-            $elements[] = $item->getData();
+        foreach ($localizedMenu as $menu) {
+            $elements[] = $menu->getData();
         }
         
         return $this->call('me/messenger_profile', [

--- a/FbBotApp.php
+++ b/FbBotApp.php
@@ -77,10 +77,8 @@ class FbBotApp
      */
     public function setGetStartedButton($payload)
     {
-        return $this->call('me/thread_settings', [
-            'setting_type' => 'call_to_actions',
-            'thread_state' => 'new_thread',
-            'call_to_actions' => [ ['payload' => $payload] ]
+        return $this->call('me/messenger_profile', [
+            'get_started' => ['payload' => $payload]
         ], self::TYPE_POST);
     }
     
@@ -92,10 +90,9 @@ class FbBotApp
      */
     public function deleteGetStartedButton()
     {
-        return $this->call('me/thread_settings', [
-            'setting_type' => 'call_to_actions',
-            'thread_state' => 'new_thread'
-        ], self::TYPE_DELETE);
+        return $this->call('me/messenger_profile', [
+            'fields' => ['get_started'],
+        ], self::TYPE_DELETE); 
     }
     
     
@@ -129,38 +126,35 @@ class FbBotApp
     
     
     /**
-     * Set Persistent Menu
+     * Set Nested Menu
      *
-     * @see https://developers.facebook.com/docs/messenger-platform/thread-settings/persistent-menu
-     * @param MessageButton[] $buttons
+     * @see https://developers.facebook.com/docs/messenger-platform/messenger-profile/persistent-menu
+     * @param Menu\MenuItem[] $menuItems
      * @return array
      */
-    public function setPersistentMenu($buttons)
+    public function setPersistentMenu($menuItems)
     {
         $elements = [];
 
-        foreach ($buttons as $btn) {
-            $elements[] = $btn->getData();
+        foreach ($menuItems as $item) {
+            $elements[] = $item->getData();
         }
-
-        return $this->call('me/thread_settings', [
-            'setting_type' => 'call_to_actions',
-            'thread_state' => 'existing_thread',
-            'call_to_actions' => $elements
+        
+        return $this->call('me/messenger_profile', [
+            'persistent_menu' => $elements
         ], self::TYPE_POST);
     }
-
+    
     /**
      * Remove Persistent Menu
      *
-     * @see https://developers.facebook.com/docs/messenger-platform/thread-settings/persistent-menu
+     * @see https://developers.facebook.com/docs/messenger-platform/messenger-profile/persistent-menu
      * @return array
      */
     public function deletePersistentMenu()
     {
-        return $this->call('me/thread_settings', [
-            'setting_type' => 'call_to_actions',
-            'thread_state' => 'existing_thread'
+        return $this->call('me/messenger_profile', [
+            'fields' => ['persistent_menu'],
         ], self::TYPE_DELETE);
     }
 

--- a/Menu/LocalizedMenu.php
+++ b/Menu/LocalizedMenu.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace pimax\Menu;
+
+/**
+ * Class LocalizedMenu
+ * @package pimax\Menu
+ */
+class LocalizedMenu
+{
+
+    private $locale ;
+    
+    private $composer_input_disabled ;
+    
+    private $menuItems;
+    
+    public function __construct($locale, $composer_input_disabled, $menuItems = null) {
+        
+        $this->locale = $locale;
+        $this->composer_input_disabled = $composer_input_disabled;
+        $this->menuItems = $menuItems;
+    }
+    
+    public function getData(){
+        $result = [
+            'locale' => $this->locale,
+            'composer_input_disabled' => $this->composer_input_disabled
+        ];
+        
+        if(isset($this->menuItems)){
+            foreach ($this->menuItems as $menuItem){
+                $result['call_to_actions'][] = $menuItem->getData();
+            }
+        }
+        return $result;
+    }
+}

--- a/Menu/MenuItem.php
+++ b/Menu/MenuItem.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace pimax\Menu;
+
+/**
+ * Class MessageButton
+ * @package pimax\Menu
+ */
+class MenuItem
+{
+    /**
+     * Web url button type
+     */
+    const TYPE_WEB = "web_url";
+
+    /**
+     * Postback button type
+     */
+    const TYPE_POSTBACK = "postback";
+    
+    /**
+     * Postback button type
+     */
+    const TYPE_NESTED = "nested";
+
+    /**
+     * Button type
+     *
+     * @var string
+     */
+    protected $type ;
+
+    /**
+     * Button title
+     *
+     * @var string
+     */
+    protected $title ;
+
+    /**
+     * Button url
+     *
+     * @var string|array
+     */
+    protected $data = null;
+    
+    /**
+     * Webview height ratio ("compact", "tall" or "full")
+     *
+     * @var null|string
+     */
+    protected $webview_height_ratio = null;
+
+    /**
+     * Messenger extensions which enable your web page to integrate with Messenger using js
+     *
+     * @var boolean
+     */
+    protected $messenger_extensions = false;
+
+    /**
+     * Fallback url to use on clients that don't support Messenger Extensions
+     *
+     * @var null|string
+     */
+    protected $fallback_url = null;
+
+    /*
+     * Set to hide to disable sharing in the webview (for sensitive info).
+     * 
+     * @var null|string
+     */
+    protected $webview_share_button = null ;
+
+    /**
+     * MessageButton constructor.
+     *
+     * @param string $type
+     * @param string $title
+     * @param string $url url or postback
+     */
+    public function __construct($type, $title, $data, $webview_height_ratio = '', $messenger_extensions = false, $fallback_url = '', $webview_share_button =  '')
+    {
+        $this->type = $type;
+        $this->title = $title;
+        $this->data = $data;
+
+        $this->webview_height_ratio = $webview_height_ratio;
+        $this->messenger_extensions = $messenger_extensions;
+        $this->fallback_url = $fallback_url;
+        $this->webview_share_button = $webview_share_button;
+
+    }
+
+    /**
+     * Get Button data
+     * 
+     * @return array
+     */
+    public function getData()
+    {
+        $result['type'] = $this->type;
+        $result['title'] = $this->title;
+
+        switch($this->type)
+        {
+            case self::TYPE_POSTBACK:
+                $result['payload'] = $this->data;
+            break;
+
+            case self::TYPE_WEB:
+              $result['url'] = $this->data;
+                
+              if ($this->webview_height_ratio) {
+                  $result['webview_height_ratio'] = $this->webview_height_ratio;
+              }
+              
+              if ($this->messenger_extensions){
+                  $result['messenger_extensions'] = $this->messenger_extensions;
+                  $result['fallback_url'] = $this->fallback_url;
+              }
+            break;
+            
+            case self::TYPE_NESTED:
+                foreach ($this->data as $item) {
+                    $result['call_to_actions'][] = $item->getData();
+                }
+            break;
+        }
+        return $result;
+    }
+}


### PR DESCRIPTION
This is related to #63

New class of MenuItem was added. This should be used to create menus instead of buttons. although it is possible to implement the same logic inside the MessageButton class I find it better to create new class for menu items since facebook started referring to it as ("menu_item object") which indicates more changes to come in the future.

New class LocalizedMenu was added. The changes allow the bot to have different items for different locales, each MenuItems group is wrapped inside its own localized menu.

Both setPersistentMenu menu and deletePersistentMenu are updated. Both are pointing to "messenger_profile" endpoint instead of "thread_settings" now.

Example of how to create persistent menu:
This code should create 2 menus:
1. menu for users with Arabic locale: contains one item "promotions"
2. menu for users from any other locale which is in this hierarchy:
.......My Account
..............|- Pay Bill
..............|- History
.....................|- History Old
.....................|- History new
..............|- Contact info
......Promotions
```
$myAccountItems[] = new \pimax\Menu\MenuItem('postback', 'Pay Bill', 'PAYBILL_PAYLOAD');
$historyItems[]   = new \pimax\Menu\MenuItem('postback', 'History Old', 'HISTORY_OLD_PAYLOAD');
$historyItems[]   = new \pimax\Menu\MenuItem('postback', 'History New', 'HISTORY_NEW_PAYLOAD');
$myAccountItems[] = new \pimax\Menu\MenuItem('nested', 'History', $historyItems);
$myAccountItems[] = new \pimax\Menu\MenuItem('postback', 'Contact_Info', 'CONTACT_INFO_PAYLOAD');

$myAccount = new \pimax\Menu\MenuItem('nested', 'My Account', $myAccountItems);
$promotions = new \pimax\Menu\MenuItem('postback', 'Promotions', 'GET_PROMOTIONS_PAYLOAD');

$enMenu = new \pimax\Menu\LocalizedMenu('default', false, [
    $myAccount,
    $promotions
]);

$arMenu = new \pimax\Menu\LocalizedMenu('ar_ar', false, [
    $promotions
]);

$localizedMenu[] = $enMenu;
$localizedMenu[] = $arMenu;

//Create the FB bot
$bot = new FbBotApp(PAGE@TOKEN);
$bot->deletePersistentMenu();
$bot->setPersistentMenu($localizedMenu);
```