### PR TITLE
Send Message using user_ref instead of id

### DIFF
--- a/Messages/Message.php
+++ b/Messages/Message.php
@@ -21,16 +21,21 @@ class Message
     protected $text = null;
 
     /**
+     * @var bool
+     */
+    protected $user_ref = false;
+
+    /**
      * Message constructor.
      *
      * @param string $recipient
      * @param string $text
      */
-    public function __construct($recipient, $text)
+    public function __construct($recipient, $text, $user_ref = false)
     {
         $this->recipient = $recipient;
         $this->text = $text;
-
+        $this->user_ref = $user_ref;
     }
 
     /**
@@ -41,9 +46,7 @@ class Message
     public function getData()
     {
         return [
-            'recipient' =>  [
-                'id' => $this->recipient
-            ],
+            'recipient' => $this->user_ref ? ['user_ref' => $this->recipient] : ['id' => $this->recipient],
             'message' => [
                 'text' => $this->text
             ]


### PR DESCRIPTION
Now you can send messages using user_ref.
Example:
$token = 'your_token_here';
$bot = new FbBotApp($token);
$result = $bot->send(new Message('your_user_ref_used_with_checkbox_plugin', 'Hi again!', true));

Check documentation for checkbox plugin:
https://developers.facebook.com/docs/messenger-platform/plugin-reference/checkbox-plugin