### PR TITLE
Added getPersistentMenu() method for convenience

### DIFF
--- a/FbBotApp.php
+++ b/FbBotApp.php
@@ -417,6 +417,19 @@ class FbBotApp
             'persistent_menu' => $elements
         ], self::TYPE_POST);
     }
+    
+    /**
+     * Get Nested Menu
+     *
+     * @see https://developers.facebook.com/docs/messenger-platform/messenger-profile/persistent-menu
+     * @return array
+     */
+    public function getPersistentMenu()
+    {
+        return $this->call('me/messenger_profile', [
+            'fields' => 'persistent_menu',
+        ], self::TYPE_GET);
+    }
 
     /**
      * Remove Persistent Menu


### PR DESCRIPTION
Added getPersistentMenu() method.

- Increases consistency
- Useful for debugging purposes
- Doesn't influence any other activity