### PR TITLE
Fix for curl-debug merge, added curl_error if any error is encountered

### DIFF
--- a/FbBotApp.php
+++ b/FbBotApp.php
@@ -33,6 +33,14 @@ class FbBotApp
      */
     protected $token = null;
 
+
+    /**
+     * Contains the last cURL error for the current session if encountered
+     *
+     * @var null|string
+     */
+    protected $curl_error = null;
+
     /**
      * FbBotApp constructor.
      * @param string $token
@@ -507,11 +515,23 @@ class FbBotApp
          *
          * @see http://php.net/manual/en/function.curl-error.php
          */
-        $curl_errors = curl_error($process);
-        if ($curl_errors) {
-            echo 'cURL Error #:' . $curl_errors;
+        $curl_error = curl_error($process);
+        if ($curl_error) {
+            $this->curl_error = $curl_error;
         }
 
         return json_decode($return, true);
     }
+
+    /**
+     * Get the last cURL error if encountered
+     *
+     * @return null|string
+     */
+    public function getCurlError()
+    {
+        return $this->curl_error;
+    }
+
+
 }


### PR DESCRIPTION
As @jason-engage [stated](https://github.com/pimax/fb-messenger-php/pull/135#issuecomment-370194766) in #135  it was wrong to use an echo inside a function, and since we don't want to mess on how the function is returning the result (using an array etc..) I added a ``$curl_erros`` variable at a global scope, the variable is set to ``null`` unless an error is encountered so someone could simple check ``$curl_errors`` for "debug means".

I think it's better to keep things this way untill the release of 2.0 where I suggest we [use exceptions for error handling](https://github.com/pimax/fb-messenger-php/issues/123#issuecomment-369763906) #123