### PR TITLE
Changing userProfile method of FbBotApp.php

### DIFF
--- a/FbBotApp.php
+++ b/FbBotApp.php
@@ -61,6 +61,18 @@ class FbBotApp
          return $this->call('me/messages', $message->getData());
      }
 
+    /**
+     * Reply a private Message
+     *
+     * @param Message $message
+     * @param Integer $id
+     * @return array
+     */
+    public function reply($message, $id)
+    {
+        return $this->call($id.'/private_replies', $message->getData());
+    }
+    
      public function batch($messages)
      {
         //Max 50 Requests per batch send

--- a/FbBotApp.php
+++ b/FbBotApp.php
@@ -61,16 +61,16 @@ class FbBotApp
          return $this->call('me/messages', $message->getData());
      }
 
-    /**
+   /**
      * Reply a private Message
      *
-     * @param Message $message
-     * @param Integer $id
+     * @param string $message
+     * @param int $id
      * @return array
      */
     public function reply($message, $id)
     {
-        return $this->call($id.'/private_replies', $message->getData());
+        return $this->call($id.'/private_replies', $message);
     }
     
      public function batch($messages)

--- a/FbBotApp.php
+++ b/FbBotApp.php
@@ -191,7 +191,7 @@ class FbBotApp
      * @return UserProfile
      */
     public function userProfile($id, $fields = 'first_name,last_name,profile_pic,locale,timezone,gender')
-    {,
+    {
         return new UserProfile($this->call($id, [
             'fields' => $fields
         ], self::TYPE_GET));

--- a/FbBotApp.php
+++ b/FbBotApp.php
@@ -190,8 +190,8 @@ class FbBotApp
      * @param string $fields
      * @return UserProfile
      */
-    public function userProfile($id, $fields = 'first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral')
-    {
+    public function userProfile($id, $fields = 'first_name,last_name,profile_pic,locale,timezone,gender')
+    {,
         return new UserProfile($this->call($id, [
             'fields' => $fields
         ], self::TYPE_GET));

--- a/FbBotApp.php
+++ b/FbBotApp.php
@@ -26,7 +26,7 @@ class FbBotApp
      *
      * @var string
      */
-    protected $apiUrl = 'https://graph.facebook.com/v2.8/';
+    protected $apiUrl = 'https://graph.facebook.com/v3.2/';
 
     /**
      * @var null|string


### PR DESCRIPTION
According to Facebook, By default, we may retrieve the id, name, first_name, last_name, and profile_pic fields 
https://developers.facebook.com/docs/messenger-platform/identity/user-profile
last_ad_referral is deprecated 
https://developers.facebook.com/docs/messenger-platform/identity/user-profile#fields
is_payment_enabled is enable only in EUA
https://developers.facebook.com/docs/messenger-platform/send-messages/buttons#buy
userProfile > gets doesn't works
To solve this, was necessary to remove above reference in userProfile methods