### PR TITLE
removing last_ad_referral & is_payment_enabled

### DIFF
--- a/FbBotApp.php
+++ b/FbBotApp.php
@@ -190,7 +190,7 @@ class FbBotApp
      * @param string $fields
      * @return UserProfile
      */
-    public function userProfile($id, $fields = 'first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral')
+    public function userProfile($id, $fields = 'first_name,last_name,profile_pic,locale,timezone,gender')
     {
         return new UserProfile($this->call($id, [
             'fields' => $fields


### PR DESCRIPTION
The FB API no longer works with when last_ad_referral & is_payment_enabled are requested.