### PR TITLE
add appsecret_proof support, useful for post 2.8 api version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.2.2 (in development)
 
 ### New features & improvements:
+- Add appsecret_proof support
 
 ### Bug fixes:
 - Hotfixes in class FbBotApp

--- a/FbBotApp.php
+++ b/FbBotApp.php
@@ -74,7 +74,7 @@ class FbBotApp
         }
         
         if (!is_null($app_secret)) {
-            $this->appsecret_proof= hash_hmac('sha256', $this->token, $app_secret); 
+            $this->appsecret_proof = hash_hmac('sha256', $this->token, $app_secret); 
         }
         
         $this->apiUrl = $this->baseApiUrl . $version . "/";

--- a/FbBotApp.php
+++ b/FbBotApp.php
@@ -47,6 +47,10 @@ class FbBotApp
      */
     protected $token = null;
 
+    /**
+     * @var null|string
+     */
+    protected $appsecret_proof = null;
 
     /**
      * Contains the last cURL error for the current session if encountered
@@ -59,15 +63,20 @@ class FbBotApp
      * FbBotApp constructor.
      * @param string $token
      * @param string $version optional
+     * @param string $app_secret optional
      */
-    public function __construct($token, $version = null)
+    public function __construct($token, $version = null, $app_secret=null)
     {
         $this->token = $token;
         
         if (is_null($version)) {
-            $version = $this->apiVersion
+            $version = $this->apiVersion;
         }
-
+        
+        if (!is_null($app_secret)) {
+            $this->appsecret_proof= hash_hmac('sha256', $this->token, $app_secret); 
+        }
+        
         $this->apiUrl = $this->baseApiUrl . $version . "/";
     }
 
@@ -518,6 +527,10 @@ class FbBotApp
     {
         $data['access_token'] = $this->token;
 
+        if (!is_null($this->appsecret_proof)){
+            $data['appsecret_proof'] = $this->appsecret_proof;
+        }
+        
         $headers = [
             'Content-Type: application/json',
         ];


### PR DESCRIPTION
add appsecret_proof support, useful for post 2.8 api version
see [Securing Graph API Requests - Facebook for Developers](https://developers.facebook.com/docs/graph-api/securing-requests/)